### PR TITLE
Added "Perfecto Mobile, Inc." to line 3

### DIFF
--- a/license
+++ b/license
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017 Quantum
+Copyright (c) 2017 Perfecto Mobile, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Saw that the license referenced "Quantum" but not our legal entity, Perfecto Mobile, Inc.