### PR TITLE
try to mute the slf4j related messages to be showing in the console

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -148,5 +148,11 @@
 			<artifactId>reportium-testng</artifactId>
 			<version>${reportium-sdk.version}</version>
 		</dependency>
+		<dependency>
+	    <groupId>org.slf4j</groupId>
+	    	<artifactId>slf4j-simple</artifactId>
+	    	<version>1.7.25</version>
+	    	<scope>test</scope>
+		</dependency>
 	</dependencies>
 </project>

--- a/src/main/resources/simplelogger.properties
+++ b/src/main/resources/simplelogger.properties
@@ -1,0 +1,34 @@
+# SLF4J's SimpleLogger configuration file
+# Simple implementation of Logger that sends all enabled log messages, for all defined loggers, to System.err.
+
+# Default logging detail level for all instances of SimpleLogger.
+# Must be one of ("trace", "debug", "info", "warn", or "error").
+# If not specified, defaults to "info".
+org.slf4j.simpleLogger.defaultLogLevel=error
+
+# Logging detail level for a SimpleLogger instance named "xxxxx".
+# Must be one of ("trace", "debug", "info", "warn", or "error").
+# If not specified, the default logging detail level is used.
+#org.slf4j.simpleLogger.log.xxxxx=
+
+# Set to true if you want the current date and time to be included in output messages.
+# Default is false, and will output the number of milliseconds elapsed since startup.
+#org.slf4j.simpleLogger.showDateTime=false
+
+# The date and time format to be used in the output messages.
+# The pattern describing the date and time format is the same that is used in java.text.SimpleDateFormat.
+# If the format is not specified or is invalid, the default format is used.
+# The default format is yyyy-MM-dd HH:mm:ss:SSS Z.
+#org.slf4j.simpleLogger.dateTimeFormat=yyyy-MM-dd HH:mm:ss:SSS Z
+
+# Set to true if you want to output the current thread name.
+# Defaults to true.
+#org.slf4j.simpleLogger.showThreadName=true
+
+# Set to true if you want the Logger instance name to be included in output messages.
+# Defaults to true.
+#org.slf4j.simpleLogger.showLogName=true
+
+# Set to true if you want the last component of the name to be included in output messages.
+# Defaults to false.
+#org.slf4j.simpleLogger.showShortLogName=false


### PR DESCRIPTION
updated pom.xml with slf4j-simple to mute following msgs:
Jun 13, 2018 4:05:47 PM org.openqa.selenium.remote.ProtocolHandshake createSession
INFO: Detected dialect: OSS
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.

added simplelogger.properties to set output threhold to error to avoid the following info output to be showing in the console
[TestNG] INFO com.perfectomobile.httpclient.HttpClient - Processing request Request[_requestType=DEVICE_INFO,_itemId=0117113284292401,_parameters=[ParameterValue[_name=responseFormat,_value=xml]],_stringParameters=<null>,_encoding=<null>]
[TestNG] INFO com.perfectomobile.httpclient.HttpClient - URL =  ...
[TestNG] INFO com.perfectomobile.httpclient.HttpClient - Response: <?xml version="1.0" encoding="UTF-8"?>
<handset modelVersion="2.21.0.0" productVersion="18.7" ...
[TestNG] INFO com.perfectomobile.httpclient.HttpClient - Response values: ...